### PR TITLE
bugfix(session-api): Refactored DataProvider CRUD operations

### DIFF
--- a/demo/src/main/java/com/example/data/DataProvider.java
+++ b/demo/src/main/java/com/example/data/DataProvider.java
@@ -58,13 +58,13 @@ public class DataProvider {
      * @throws SQLException if a database access error occurs
      */
     public long saveSession(Session s) throws SQLException {
-        String sql = "INSERT INTO sessions (session_date, session_time, is_gi, instructor, rank) VALUES (?, ?, ?, ?, ?)";
+        String sql = "INSERT INTO sessions (session_date, session_time, is_gi, instructor, currentBelt) VALUES (?, ?, ?, ?, ?)";
         try (Connection c = getConnection(); PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             ps.setDate(1, Date.valueOf(s.getDate()));
             ps.setTime(2, Time.valueOf(s.getTime()));
             ps.setBoolean(3, s.isGi());
             ps.setString(4, s.getInstructor());
-            ps.setString(5, s.getRank());
+            ps.setString(5, s.getcurrentBelt());
             ps.executeUpdate();
             try (ResultSet rs = ps.getGeneratedKeys()) {
                 if (rs.next()) {
@@ -163,7 +163,7 @@ public class DataProvider {
             ps.setTime(2, Time.valueOf(s.getTime()));
             ps.setBoolean(3, s.isGi());
             ps.setString(4, s.getInstructor());
-            ps.setString(5, s.getRank());
+            ps.setString(5, s.getcurrentBelt());
             ps.setLong(6, s.getId());
             return ps.executeUpdate() > 0;
         }
@@ -196,7 +196,7 @@ public class DataProvider {
         s.setTime(t != null ? t.toLocalTime() : LocalTime.MIDNIGHT);
         s.setGi(rs.getBoolean("is_gi"));
         s.setInstructor(rs.getString("instructor"));
-        s.setRank(rs.getString("rank"));
+        s.setcurrentBelt(rs.getString("currentBelt"));
         return s;
     }
 

--- a/demo/src/main/java/com/example/model/Session.java
+++ b/demo/src/main/java/com/example/model/Session.java
@@ -15,7 +15,7 @@ import java.util.List;
  * time, 
  * whether session was gi or no-gi, 
  * instructor, 
- * user's rank at the time of the session, 
+ * user's currentBelt at the time of the session, 
  * and a list of rolls that took place during the session. 
  * This class serves as a data model for training sessions that can be tracked and analyzed in the BJJ Progress Tracker application.
  */
@@ -25,7 +25,7 @@ public class Session {
     private LocalTime time;
     private boolean isGi;
     private String instructor;
-    private String rank;    //TODO: refactor to "currentBelt" (2/3/26)
+    private String currentBelt;    
     private List<Roll> rolls = new ArrayList<>();
 
     /**
@@ -40,16 +40,16 @@ public class Session {
      * @param time the time of the training session
      * @param isGi whether the session was a gi or no-gi session
      * @param instructor the instructor of the training session
-     * @param rank the user's rank at the time of the training session
+     * @param currentBelt the user's currentBelt at the time of the training session
      * @param rolls the list of rolls that took place during the training session
      */
-    public Session(long id, LocalDate date, LocalTime time, boolean isGi, String instructor, String rank, List<Roll> rolls) {
+    public Session(long id, LocalDate date, LocalTime time, boolean isGi, String instructor, String currentBelt, List<Roll> rolls) {
         this.id = id;
         this.date = date;
         this.time = time;
         this.isGi = isGi;
         this.instructor = instructor;
-        this.rank = rank;
+        this.currentBelt = currentBelt;
         this.rolls = rolls;
     }
 
@@ -134,19 +134,19 @@ public class Session {
     }
 
     /**
-     * Get the user's rank at the time of the training session
-     * @return the user's rank at the time of the training session
+     * Get the user's currentBelt at the time of the training session
+     * @return the user's currentBelt at the time of the training session
      */
-    public String getRank() {
-        return rank;
+    public String getcurrentBelt() {
+        return currentBelt;
     }
 
     /**
-     * Set the user's rank at the time of the training session
-     * @param rank the user's rank at the time of the training session
+     * Set the user's currentBelt at the time of the training session
+     * @param currentBelt the user's currentBelt at the time of the training session
      */
-    public void setRank(String rank) {
-        this.rank = rank;
+    public void setcurrentBelt(String currentBelt) {
+        this.currentBelt = currentBelt;
     }
     
     /**
@@ -179,6 +179,6 @@ public class Session {
      */
     @Override
     public String toString() {
-        return "Session ID: " + id + ", Date: " + date + ", Time: " + time + ", Is Gi: " + isGi + ", Instructor: " + instructor + ", Rank: " + rank + ", Rolls: " + rolls;
+        return "Session ID: " + id + ", Date: " + date + ", Time: " + time + ", Is Gi: " + isGi + ", Instructor: " + instructor + ", currentBelt: " + currentBelt + ", Rolls: " + rolls;
     }
 }


### PR DESCRIPTION
Everywhere that 'rank' was referrenced, I changed it to 'currentBelt'. This was because the corresponding table in the database was named 'currentBelt'. This fixed the getAllSessions on the API.